### PR TITLE
Adjust etcd-registrar to work on openshift

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ etcd-registrar \
     --etcd-url=$ETCD_URL \
     --etcd-base=$ETCD_BASE \
     --service=$SERVICE \
-    --name=$NAME \
+    --port=$PORT \
     --info=$INFO \
     --ttl=$TTL \
     --list=$LIST


### PR DESCRIPTION
Analogous to the promster [PR 1](https://github.com/flaviostutz/promster/pull/1), this PR adjusts the etcd-registrar to allow the sidecar application to be monitored in a k8s/openshift environment. 

Instead of the service name, we register the ip address along with a user provided port at the etcd registry. The port is now a mandatory parameter to the etcd-registrar, instead of name.